### PR TITLE
use env utility to find the correct php to use

### DIFF
--- a/librarian
+++ b/librarian
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 if (php_sapi_name() !== 'cli') {


### PR DESCRIPTION
This is a minor change to update `librarian` to use the [env utility](https://ss64.com/bash/env.html) to find the correct PHP to use in the environment `PATH`. Otherwise, `/usr/bin/php` is my system PHP, which is running `7.3.24` right now, and has this nasty message attached to it on macOS:

```console
$ /usr/bin/php --version
WARNING: PHP is not recommended
PHP is included in macOS for compatibility with legacy software.
Future versions of macOS will not include PHP.
PHP 7.3.24-(to be removed in future macOS) (cli) (built: May  8 2021 09:40:37) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.3.24, Copyright (c) 1998-2018 Zend Technologies
```