### PR TITLE
Fix two minor bugs

### DIFF
--- a/app/Command/Web/FeedController.php
+++ b/app/Command/Web/FeedController.php
@@ -35,9 +35,9 @@ class FeedController extends WebController
         foreach ($content_list as $content) {
             $item = new Item();
             $item
-                ->title($content->title)
-                ->description('<div>'.$content->description.'</div>')
-                ->contentEncoded('<div>'.$content->description.'</div>')
+                ->title($content->title ?? '')
+                ->description('<div>'.($content->description ?? '').'</div>')
+                ->contentEncoded('<div>'.($content->description ?? '').'</div>')
                 ->url($this->getApp()->config->site_url . '/' . $content->getLink())
                 ->author($this->getApp()->config->site_author)
                 ->pubDate(strtotime($content->getDate()))

--- a/app/Resources/themes/default/error/5xx.html.twig
+++ b/app/Resources/themes/default/error/5xx.html.twig
@@ -1,4 +1,4 @@
-{% extends 'main.html.twig' %}
+{% extends 'base.html.twig' %}
 
 {% block title %}Error{% endblock %}
 


### PR DESCRIPTION
## `/feed` route error when title/description are missing

When loading `/feed` using the default project template (and no other posts), the content loader includes the `about.md` page, and no title or description appear to be set (even though I see them in the front matter). That might be a separate bug entirely, but this PR defaults to an empty string if title and description are not set, so that the feed route loads without an error.

## Error page exception

I modified the `index.php` to use the error controller when catching a generic `Throwable`:

```php
try {
    /** @var RouterServiceProvider $router */
    $route = $app->router->getCallableRoute();
    $app->runCommand(['minicli', 'web', $route]);
} catch (RouteNotFoundException $exception) {
    $notFound = new NotFoundController();
    $notFound->boot($app);
    $notFound->handle();
} catch (Throwable $throwable) {
    $error = new ErrorController();
    $error->boot($app);
    $error->handle();
}
```

In doing so, I hit an exception because `5xx.html.twig` was trying to extend `main.html.twig` instead of `base.html.twig`.